### PR TITLE
Add layout overview and expand component list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# windows-98-mini-homepage
+# Windows 98 Mini Homepage
+
+This project aims to recreate a small homepage with a classic Windows 98 look. Documentation lives alongside code so both humans and the AI can follow the design.
+
+## Development Plan
+
+1. Set up the base HTML layout with a Windows 98 theme.
+2. Use modular UI components such as the taskbar, start menu and windows.
+3. Write design details for each component in `component.md` before coding.
+4. Keep this README updated with milestones and goals.
+
+All markdown files serve as a shared medium for design discussions.
+The overall component hierarchy is documented in `layout.md` and each
+component is described in detail inside `component.md`.
+
+## Architecture Overview
+
+1. **Hybrid SPA/MPA**
+   - Some icons open modal windows on the same page.
+   - Others route to separate pages.
+2. **Component-based UI**
+   - Every visible element is a component driven by props and context.
+3. **Configuration Files**
+   - Icons, wallpapers and cursors defined in static JSON or TS config.
+4. **State Management**
+   - Start with React Context for menus and modals; allow swapping to Zustand later.
+5. **Routing and Build**
+   - GitHub Pages hosts the site built with Vite. Pages live under `pages/`.
+
+### Core Design Principles
+
+1. **Data driven UI** – icon and window definitions come from config.
+2. **Component centric with abstracted state** – each part is independent but uses shared context.
+3. **Flexible structure first** – start with placeholder components to keep the architecture open.

--- a/component.md
+++ b/component.md
@@ -1,0 +1,51 @@
+# Component Design Notes
+
+This document records each UI component used in the project.  All entries focus
+on structure first, allowing features to evolve over time. Whenever new
+components are introduced they should be added here and referenced in
+`layout.md`.
+
+## Wallpaper
+- Renders the desktop background image chosen from configuration.
+
+## Desktop
+- Container for all desktop icons.
+
+## DesktopIcon
+- Represents a single icon on the desktop.
+- Behavior determined by `routeType` (`modal` or `external`).
+
+## WindowArea
+- Holds all active `WindowModal` components.
+- Manages z-index stacking and window positioning via context.
+
+## WindowModal
+- Classic Windows 98 style window.
+- Receives content and controls from props.
+
+## Taskbar
+- Fixed bar at the bottom of the screen.
+- Hosts `StartButton`, `OpenedWindowsList` and `TimeDisplay`.
+
+### StartButton
+- Opens the `StartMenu` when clicked.
+
+### OpenedWindowsList
+- Displays currently open windows for quick switching.
+
+### TimeDisplay
+- Shows the current time, formatted like the original OS clock.
+
+## StartMenu
+- Pop-up menu for launching programs or opening links defined in config.
+
+## ContextMenu
+- Right-click menu providing actions based on the clicked area.
+
+## PointerTheme
+- Renders custom cursor icons; managed globally.
+
+## RouteManager
+- Handles navigation to external pages while keeping internal state intact.
+
+Future components or updates should extend this file with additional notes.

--- a/layout.md
+++ b/layout.md
@@ -1,0 +1,26 @@
+# Layout Overview
+
+The project follows a component hierarchy inspired by Windows 98.
+This file records how components fit together so that everyone can easily keep
+track of the structure.
+
+```
+<App>
+ ├── <Wallpaper />           // background image
+ ├── <Desktop>
+ │     └── <DesktopIcon />   // multiple icons
+ ├── <WindowArea>            // container for open windows
+ │     └── <WindowModal />
+ ├── <Taskbar>
+ │     ├── <StartButton />
+ │     ├── <OpenedWindowsList />
+ │     └── <TimeDisplay />
+ ├── <StartMenu />           // start menu dropdown
+ ├── <ContextMenu />         // right-click menu
+ ├── <PointerTheme />        // custom cursor rendering
+ └── <RouteManager />        // handles external page routing
+```
+
+The order here reflects how the main application composes its interface. Each
+component will have an entry in `component.md` describing its purpose and any
+props or state requirements.


### PR DESCRIPTION
## Summary
- document component hierarchy in `layout.md`
- expand `component.md` with descriptions for each UI element
- mention design docs in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ec690a2c8832bbc63d782f11245b1