### PR TITLE
Remove images, use placeholder styles

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,3 @@
+# Styling Approach
+
+This project requires a Windows 98 look and feel. Tailwind CSS was considered, but replicating the classic UI would require extensive overrides. To keep the styles straightforward and fully customizable, a small handcrafted CSS file (`src/styles/win98.css`) is used instead of Tailwind.

--- a/dist/components/Desktop/Desktop.js
+++ b/dist/components/Desktop/Desktop.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import DesktopIcon from '../DesktopIcon/DesktopIcon';
+const Desktop = () => (_jsx("div", { className: "desktop", children: _jsx(DesktopIcon, {}) }));
+export default Desktop;

--- a/dist/components/DesktopIcon/DesktopIcon.js
+++ b/dist/components/DesktopIcon/DesktopIcon.js
@@ -1,0 +1,3 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+const DesktopIcon = () => (_jsxs("div", { className: "desktop-icon", children: [_jsx("div", { className: "icon-placeholder" }), _jsx("span", { style: { fontSize: '12px', textAlign: 'center' }, children: "Notepad" })] }));
+export default DesktopIcon;

--- a/dist/components/Taskbar/Taskbar.js
+++ b/dist/components/Taskbar/Taskbar.js
@@ -1,0 +1,3 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+const Taskbar = () => (_jsx("div", { className: "taskbar", children: _jsx("span", { children: "Start" }) }));
+export default Taskbar;

--- a/dist/components/Wallpaper.js
+++ b/dist/components/Wallpaper.js
@@ -1,0 +1,3 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+const Wallpaper = () => (_jsx("div", { className: "wallpaper" }));
+export default Wallpaper;

--- a/dist/components/WindowArea/WindowArea.js
+++ b/dist/components/WindowArea/WindowArea.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import WindowModal from '../WindowModal/WindowModal';
+const WindowArea = () => (_jsx("div", { className: "window-area", children: _jsx(WindowModal, {}) }));
+export default WindowArea;

--- a/dist/components/WindowModal/WindowModal.js
+++ b/dist/components/WindowModal/WindowModal.js
@@ -1,0 +1,3 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+const WindowModal = () => (_jsxs("div", { className: "window-modal", children: [_jsxs("div", { className: "title-bar", children: [_jsx("span", { children: "Notepad" }), _jsx("button", { className: "close-btn", children: "x" })] }), _jsx("div", { className: "content", children: "Hello from Notepad" })] }));
+export default WindowModal;

--- a/dist/layout/AppLayout.js
+++ b/dist/layout/AppLayout.js
@@ -1,0 +1,7 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import Wallpaper from '../components/Wallpaper';
+import Desktop from '../components/Desktop/Desktop';
+import WindowArea from '../components/WindowArea/WindowArea';
+import Taskbar from '../components/Taskbar/Taskbar';
+const AppLayout = () => (_jsxs("div", { style: { position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }, children: [_jsx(Wallpaper, {}), _jsx(Desktop, {}), _jsx(WindowArea, {}), _jsx(Taskbar, {})] }));
+export default AppLayout;

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,5 +1,8 @@
-"use strict";
-const root = document.getElementById('root');
-if (root) {
-    root.textContent = 'Hello World';
+import { jsx as _jsx } from "react/jsx-runtime";
+import ReactDOM from 'react-dom/client';
+import AppLayout from './layout/AppLayout';
+const rootEl = document.getElementById('root');
+if (rootEl) {
+    const root = ReactDOM.createRoot(rootEl);
+    root.render(_jsx(AppLayout, {}));
 }

--- a/index.html
+++ b/index.html
@@ -4,9 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Windows 98 Mini Homepage</title>
-</head>
-<body>
-  <div id="root"></div>
-  <script type="module" src="./dist/main.js"></script>
-</body>
+  <link rel="stylesheet" href="./src/styles/win98.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./dist/bundle.js"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "windows-98-mini-homepage",
+  "private": true,
+  "scripts": {
+    "build": "node scripts/build.js"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "esbuild": "0.20.0",
+    "typescript": "5.4.0"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,10 @@
+const esbuild = require('esbuild');
+
+esbuild.build({
+  entryPoints: ['src/main.tsx'],
+  bundle: true,
+  outfile: 'dist/bundle.js',
+  platform: 'browser',
+  loader: { '.png': 'file' },
+  jsx: 'automatic'
+}).catch(() => process.exit(1));

--- a/src/components/Desktop/Desktop.tsx
+++ b/src/components/Desktop/Desktop.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import DesktopIcon from '../DesktopIcon/DesktopIcon';
+
+const Desktop: React.FC = () => (
+  <div className="desktop">
+      <DesktopIcon />
+    </div>
+);
+
+export default Desktop;

--- a/src/components/DesktopIcon/DesktopIcon.tsx
+++ b/src/components/DesktopIcon/DesktopIcon.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+const DesktopIcon: React.FC = () => (
+  <div className="desktop-icon">
+      <div className="icon-placeholder" />
+      <span style={{ fontSize: '12px', textAlign: 'center' }}>Notepad</span>
+  </div>
+);
+
+export default DesktopIcon;

--- a/src/components/Taskbar/Taskbar.tsx
+++ b/src/components/Taskbar/Taskbar.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Taskbar: React.FC = () => (
+  <div className="taskbar">
+      <span>Start</span>
+    </div>
+);
+
+export default Taskbar;

--- a/src/components/Wallpaper.tsx
+++ b/src/components/Wallpaper.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+const Wallpaper: React.FC = () => (
+  <div className="wallpaper" />
+);
+
+export default Wallpaper;

--- a/src/components/WindowArea/WindowArea.tsx
+++ b/src/components/WindowArea/WindowArea.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import WindowModal from '../WindowModal/WindowModal';
+
+const WindowArea: React.FC = () => (
+  <div className="window-area">
+      <WindowModal />
+    </div>
+);
+
+export default WindowArea;

--- a/src/components/WindowModal/WindowModal.tsx
+++ b/src/components/WindowModal/WindowModal.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const WindowModal: React.FC = () => (
+  <div className="window-modal">
+      <div className="title-bar">
+        <span>Notepad</span>
+        <button className="close-btn">x</button>
+      </div>
+      <div className="content">Hello from Notepad</div>
+  </div>
+);
+
+export default WindowModal;

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,9 @@
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Wallpaper from '../components/Wallpaper';
+import Desktop from '../components/Desktop/Desktop';
+import WindowArea from '../components/WindowArea/WindowArea';
+import Taskbar from '../components/Taskbar/Taskbar';
+
+const AppLayout: React.FC = () => (
+  <div style={{ position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }}>
+    <Wallpaper />
+    <Desktop />
+    <WindowArea />
+    <Taskbar />
+  </div>
+);
+
+export default AppLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
-const root = document.getElementById('root');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import AppLayout from './layout/AppLayout';
 
-if (root) {
-  root.textContent = 'Hello World';
+const rootEl = document.getElementById('root');
+
+if (rootEl) {
+  const root = ReactDOM.createRoot(rootEl);
+  root.render(<AppLayout />);
 }

--- a/src/react-shim.d.ts
+++ b/src/react-shim.d.ts
@@ -1,0 +1,23 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}
+
+declare module 'react' {
+  export interface FC<P = {}> {
+    (props: P): any;
+  }
+  const Fragment: any;
+  export { Fragment };
+}
+
+declare module 'react/jsx-runtime' {
+  export const jsx: any;
+  export const jsxs: any;
+  export const Fragment: any;
+}
+
+declare module 'react-dom/client' {
+  export function createRoot(container: Element | DocumentFragment): { render(children: any): void };
+}

--- a/src/styles/win98.css
+++ b/src/styles/win98.css
@@ -1,0 +1,96 @@
+body {
+  margin: 0;
+  overflow: hidden;
+}
+
+.wallpaper {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: #008080;
+  z-index: 0;
+}
+
+.desktop {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.desktop-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+.icon-placeholder {
+  width: 32px;
+  height: 32px;
+  background: #0078d4;
+  margin-bottom: 0.25rem;
+}
+
+.window-area {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.window-modal {
+  position: absolute;
+  top: 5rem;
+  left: 5rem;
+  width: 16rem;
+  border: 1px solid #000;
+  background: #f0f0f0;
+  z-index: 20;
+}
+
+.window-modal .title-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #0078d4;
+  color: #fff;
+  padding: 0 0.5rem;
+  height: 1.5rem;
+  font-size: 0.875rem;
+}
+
+.window-modal .close-btn {
+  width: 1rem;
+  height: 1rem;
+  background: #ff5555;
+  color: #fff;
+  text-align: center;
+  line-height: 1rem;
+  font-size: 0.75rem;
+  border: none;
+}
+
+.window-modal .content {
+  padding: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.taskbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2rem;
+  background: #c0c0c0;
+  border-top: 1px solid #fff;
+  border-left: 1px solid #fff;
+  display: flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  z-index: 20;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,11 @@
     "module": "ES2020",
     "outDir": "dist",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- remove binary image assets from the repository
- adjust Wallpaper and DesktopIcon components to use styled placeholders
- update CSS to style new placeholder elements

## Testing
- `node scripts/build.js` *(fails: Cannot find module 'esbuild')*
- `npx tsc` *(fails: npm could not download packages)*

------
https://chatgpt.com/codex/tasks/task_e_685f4a478624832bb1e97b1e051f8e9f