### PR TITLE
Improve desktop icons

### DIFF
--- a/dist/components/Desktop/Desktop.js
+++ b/dist/components/Desktop/Desktop.js
@@ -1,4 +1,4 @@
-import { jsx as _jsx } from "react/jsx-runtime";
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import DesktopIcon from '../DesktopIcon/DesktopIcon';
-const Desktop = () => (_jsx("div", { className: "desktop", children: _jsx(DesktopIcon, {}) }));
+const Desktop = () => (_jsxs("div", { className: "desktop", children: [_jsx(DesktopIcon, { label: "\uB0B4 \uCEF4\uD4E8\uD130" }), _jsx(DesktopIcon, { label: "\uB0B4 \uBB38\uC11C" }), _jsx(DesktopIcon, { label: "\uC778\uD130\uB137" }), _jsx(DesktopIcon, { label: "Notepad" })] }));
 export default Desktop;

--- a/dist/components/DesktopIcon/DesktopIcon.js
+++ b/dist/components/DesktopIcon/DesktopIcon.js
@@ -1,3 +1,3 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-const DesktopIcon = () => (_jsxs("div", { className: "desktop-icon", children: [_jsx("div", { className: "icon-placeholder" }), _jsx("span", { style: { fontSize: '12px', textAlign: 'center' }, children: "Notepad" })] }));
+const DesktopIcon = ({ label }) => (_jsxs("div", { className: "desktop-icon", children: [_jsx("div", { className: "icon-placeholder" }), _jsx("span", { style: { fontSize: '12px', textAlign: 'center' }, children: label })] }));
 export default DesktopIcon;

--- a/src/components/Desktop/Desktop.tsx
+++ b/src/components/Desktop/Desktop.tsx
@@ -3,8 +3,11 @@ import DesktopIcon from '../DesktopIcon/DesktopIcon';
 
 const Desktop: React.FC = () => (
   <div className="desktop">
-      <DesktopIcon />
-    </div>
+    <DesktopIcon label="내 컴퓨터" />
+    <DesktopIcon label="내 문서" />
+    <DesktopIcon label="인터넷" />
+    <DesktopIcon label="Notepad" />
+  </div>
 );
 
 export default Desktop;

--- a/src/components/DesktopIcon/DesktopIcon.tsx
+++ b/src/components/DesktopIcon/DesktopIcon.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-const DesktopIcon: React.FC = () => (
+
+interface Props {
+  label: string;
+}
+
+const DesktopIcon: React.FC<Props> = ({ label }) => (
   <div className="desktop-icon">
-      <div className="icon-placeholder" />
-      <span style={{ fontSize: '12px', textAlign: 'center' }}>Notepad</span>
+    <div className="icon-placeholder" />
+    <span style={{ fontSize: '12px', textAlign: 'center' }}>{label}</span>
   </div>
 );
 

--- a/src/styles/win98.css
+++ b/src/styles/win98.css
@@ -15,11 +15,13 @@ body {
 .desktop {
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 5rem);
+  grid-auto-rows: 5rem;
+  align-content: flex-start;
+  justify-content: flex-start;
+  padding: 0.5rem;
   z-index: 10;
-  pointer-events: none;
 }
 
 .desktop-icon {


### PR DESCRIPTION
## Summary
- show taskbar on page
- add three placeholder icons
- support custom labels for DesktopIcon

## Testing
- `npm run build` *(fails: cannot find module 'esbuild')*
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68600c7224d4832b8d6561cc129dd1fc