### PR TITLE
Add Windows 98 cursor

### DIFF
--- a/dist/components/PointerTheme/PointerTheme.js
+++ b/dist/components/PointerTheme/PointerTheme.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+const cursorData = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMicgaGVpZ2h0PSczMic+PHBvbHlnb24gZmlsbD0nd2hpdGUnIHN0cm9rZT0nYmxhY2snIHBvaW50cz0nMCwwIDAsMjQgNiwxOCAxMiwzMiAxNiwzMCAxMCwxOCAxOCwxOCcvPjwvc3ZnPg==';
+const PointerTheme = () => {
+    useEffect(() => {
+        const prev = document.body.style.cursor;
+        document.body.style.cursor = `url(${cursorData}) 0 0, auto`;
+        return () => {
+            document.body.style.cursor = prev;
+        };
+    }, []);
+    return null;
+};
+export default PointerTheme;

--- a/dist/layout/AppLayout.js
+++ b/dist/layout/AppLayout.js
@@ -3,5 +3,6 @@ import Wallpaper from '../components/Wallpaper';
 import Desktop from '../components/Desktop/Desktop';
 import WindowArea from '../components/WindowArea/WindowArea';
 import Taskbar from '../components/Taskbar/Taskbar';
-const AppLayout = () => (_jsxs("div", { style: { position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }, children: [_jsx(Wallpaper, {}), _jsx(Desktop, {}), _jsx(WindowArea, {}), _jsx(Taskbar, {})] }));
+import PointerTheme from '../components/PointerTheme/PointerTheme';
+const AppLayout = () => (_jsxs("div", { style: { position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }, children: [_jsx(Wallpaper, {}), _jsx(Desktop, {}), _jsx(WindowArea, {}), _jsx(Taskbar, {}), _jsx(PointerTheme, {})] }));
 export default AppLayout;

--- a/src/components/PointerTheme/PointerTheme.tsx
+++ b/src/components/PointerTheme/PointerTheme.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+
+const cursorData =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMicgaGVpZ2h0PSczMic+PHBvbHlnb24gZmlsbD0nd2hpdGUnIHN0cm9rZT0nYmxhY2snIHBvaW50cz0nMCwwIDAsMjQgNiwxOCAxMiwzMiAxNiwzMCAxMCwxOCAxOCwxOCcvPjwvc3ZnPg==';
+
+const PointerTheme: React.FC = () => {
+  useEffect(() => {
+    const prev = document.body.style.cursor;
+    document.body.style.cursor = `url(${cursorData}) 0 0, auto`;
+    return () => {
+      document.body.style.cursor = prev;
+    };
+  }, []);
+
+  return null;
+};
+
+export default PointerTheme;

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import Wallpaper from '../components/Wallpaper';
 import Desktop from '../components/Desktop/Desktop';
 import WindowArea from '../components/WindowArea/WindowArea';
 import Taskbar from '../components/Taskbar/Taskbar';
+import PointerTheme from '../components/PointerTheme/PointerTheme';
 
 const AppLayout: React.FC = () => (
   <div style={{ position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }}>
@@ -10,6 +11,7 @@ const AppLayout: React.FC = () => (
     <Desktop />
     <WindowArea />
     <Taskbar />
+    <PointerTheme />
   </div>
 );
 

--- a/src/react-shim.d.ts
+++ b/src/react-shim.d.ts
@@ -8,6 +8,10 @@ declare module 'react' {
   export interface FC<P = {}> {
     (props: P): any;
   }
+  export function useEffect(
+    effect: () => void | (() => void),
+    deps?: any[]
+  ): void;
   const Fragment: any;
   export { Fragment };
 }


### PR DESCRIPTION
## Summary
- enable Windows 98 style mouse cursor
- allow `useEffect` in the React shim

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*
- `tsc`

------
https://chatgpt.com/codex/tasks/task_e_68600e9c7528832ba6ea729a7202f292