### PR TITLE
Add start menu UI

### DIFF
--- a/component.md
+++ b/component.md
@@ -38,6 +38,9 @@ components are introduced they should be added here and referenced in
 
 ## StartMenu
 - Pop-up menu for launching programs or opening links defined in config.
+- Left sidebar shows vertical "Windows" text on a navy background.
+- Menu items list icons and labels; hover turns the row deep blue.
+- For now it renders statically above the Start button.
 
 ## ContextMenu
 - Right-click menu providing actions based on the clicked area.

--- a/dist/components/StartMenu/StartMenu.js
+++ b/dist/components/StartMenu/StartMenu.js
@@ -1,0 +1,17 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+const StartMenu = () => (_jsxs("div", { className: "start-menu", children: [
+  _jsxs("div", { className: "start-menu-bar", children: _jsx("span", { className: "bar-text", children: "Windows" }) }),
+  _jsxs("ul", { className: "start-menu-list", children: [
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uD504\uB85C\uADF8\uB7A8(P) ", _jsx("span", { className: "item-arrow", children: "\u25B6" })] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC990\uACA8\uCC3E\uAE30(A) ", _jsx("span", { className: "item-arrow", children: "\u25B6" })] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uBB38\uC11C(D)"] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC124\uC815(S) ", _jsx("span", { className: "item-arrow", children: "\u25B6" })] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uCC3E\uAE30(F)"] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uB3C4\uC6B8\uB9D0(H)"] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC2E4\uD589(R)"] }),
+    _jsx("hr", { className: "start-menu-separator" }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uB85C\uADF8\uC624\uD504(L)"] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC2DC\uC2A4\uD15C \uC885\uB8CC(U)"] })
+  ] })
+] }));
+export default StartMenu;

--- a/dist/layout/AppLayout.js
+++ b/dist/layout/AppLayout.js
@@ -3,6 +3,7 @@ import Wallpaper from '../components/Wallpaper.js';
 import Desktop from '../components/Desktop/Desktop.js';
 import WindowArea from '../components/WindowArea/WindowArea.js';
 import Taskbar from '../components/Taskbar/Taskbar.js';
+import StartMenu from '../components/StartMenu/StartMenu.js';
 import PointerTheme from '../components/PointerTheme/PointerTheme.js';
-const AppLayout = () => (_jsxs("div", { style: { position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }, children: [_jsx(Wallpaper, {}), _jsx(Desktop, {}), _jsx(WindowArea, {}), _jsx(Taskbar, {}), _jsx(PointerTheme, {})] }));
+const AppLayout = () => (_jsxs("div", { style: { position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }, children: [_jsx(Wallpaper, {}), _jsx(Desktop, {}), _jsx(WindowArea, {}), _jsx(Taskbar, {}), _jsx(StartMenu, {}), _jsx(PointerTheme, {})] }));
 export default AppLayout;

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const StartMenu: React.FC = () => (
+  <div className="start-menu">
+    <div className="start-menu-bar">
+      <span className="bar-text">Windows</span>
+    </div>
+    <ul className="start-menu-list">
+      <li className="start-menu-item"><span className="item-icon" />프로그램(P)  <span className="item-arrow">▶</span></li>
+      <li className="start-menu-item"><span className="item-icon" />즐겨찾기(A)  <span className="item-arrow">▶</span></li>
+      <li className="start-menu-item"><span className="item-icon" />문서(D)</li>
+      <li className="start-menu-item"><span className="item-icon" />설정(S) <span className="item-arrow">▶</span></li>
+      <li className="start-menu-item"><span className="item-icon" />찾기(F)</li>
+      <li className="start-menu-item"><span className="item-icon" />도움말(H)</li>
+      <li className="start-menu-item"><span className="item-icon" />실행(R)</li>
+      <hr className="start-menu-separator" />
+      <li className="start-menu-item"><span className="item-icon" />로그오프(L)</li>
+      <li className="start-menu-item"><span className="item-icon" />시스템 종료(U)</li>
+    </ul>
+  </div>
+);
+
+export default StartMenu;

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -4,6 +4,7 @@ import Desktop from '../components/Desktop/Desktop';
 import WindowArea from '../components/WindowArea/WindowArea';
 import Taskbar from '../components/Taskbar/Taskbar';
 import PointerTheme from '../components/PointerTheme/PointerTheme';
+import StartMenu from '../components/StartMenu/StartMenu';
 
 const AppLayout: React.FC = () => (
   <div style={{ position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }}>
@@ -11,6 +12,7 @@ const AppLayout: React.FC = () => (
     <Desktop />
     <WindowArea />
     <Taskbar />
+    <StartMenu />
     <PointerTheme />
   </div>
 );

--- a/src/styles/win98.css
+++ b/src/styles/win98.css
@@ -127,3 +127,70 @@ body {
   background: #000;
   color: #fff;
 }
+
+.start-menu {
+  position: fixed;
+  bottom: 2rem;
+  left: 0;
+  width: 240px;
+  display: flex;
+  background: #c0c0c0;
+  border-top: 2px solid #fff;
+  border-left: 2px solid #fff;
+  border-bottom: 2px solid #404040;
+  border-right: 2px solid #404040;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+  z-index: 30;
+}
+
+.start-menu-bar {
+  width: 40px;
+  background: #000080;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.start-menu-bar .bar-text {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 12px;
+}
+
+.start-menu-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  width: 100%;
+}
+
+.start-menu-item {
+  display: flex;
+  align-items: center;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 14px;
+  cursor: default;
+}
+
+.start-menu-item:hover {
+  background: #000080;
+  color: #fff;
+}
+
+.item-icon {
+  width: 16px;
+  height: 16px;
+  background: #808080;
+  margin-right: 8px;
+}
+
+.item-arrow {
+  margin-left: auto;
+}
+
+.start-menu-separator {
+  border-top: 1px solid #808080;
+  margin: 4px 4px;
+}


### PR DESCRIPTION
## Summary
- implement `StartMenu` component
- style start menu with classic Windows 98 look
- integrate the menu into the layout
- document start menu design

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686154746308832bae546af20737fa2b