### PR TITLE
Implement start menu toggle

### DIFF
--- a/src/components/Taskbar/StartButton.tsx
+++ b/src/components/Taskbar/StartButton.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
-const StartButton: React.FC = () => (
-  <button type="button" className="start-button">시작</button>
+interface Props {
+  onClick: () => void;
+}
+
+const StartButton: React.FC<Props> = ({ onClick }) => (
+  <button type="button" className="start-button" onClick={onClick}>시작</button>
 );
 
 export default StartButton;

--- a/src/components/Taskbar/Taskbar.tsx
+++ b/src/components/Taskbar/Taskbar.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import StartButton from './StartButton';
 import TimeDisplay from './TimeDisplay';
 
-const Taskbar: React.FC = () => (
+interface Props {
+  onStartClick: () => void;
+}
+
+const Taskbar: React.FC<Props> = ({ onStartClick }) => (
   <div className="taskbar">
-    <StartButton />
+    <StartButton onClick={onStartClick} />
     <div style={{ flexGrow: 1 }} />
     <TimeDisplay />
   </div>

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -6,15 +6,20 @@ import Taskbar from '../components/Taskbar/Taskbar';
 import PointerTheme from '../components/PointerTheme/PointerTheme';
 import StartMenu from '../components/StartMenu/StartMenu';
 
-const AppLayout: React.FC = () => (
-  <div style={{ position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }}>
-    <Wallpaper />
-    <Desktop />
-    <WindowArea />
-    <Taskbar />
-    <StartMenu />
-    <PointerTheme />
-  </div>
-);
+const AppLayout: React.FC = () => {
+  const [showMenu, setShowMenu] = React.useState(false);
+  const toggleMenu = () => setShowMenu((v) => !v);
+
+  return (
+    <div style={{ position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }}>
+      <Wallpaper />
+      <Desktop />
+      <WindowArea />
+      <Taskbar onStartClick={toggleMenu} />
+      {showMenu && <StartMenu />}
+      <PointerTheme />
+    </div>
+  );
+};
 
 export default AppLayout;


### PR DESCRIPTION
## Summary
- make `StartButton` accept click handler
- add `onStartClick` prop to `Taskbar`
- show or hide `StartMenu` from `AppLayout`

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_686156477e58832bb2b3800f5ab181c9