### PR TITLE
Implement start menu toggle and icon

### DIFF
--- a/dist/components/Taskbar/StartButton.js
+++ b/dist/components/Taskbar/StartButton.js
@@ -1,5 +1,8 @@
-import { jsx as _jsx } from "react/jsx-runtime";
-const StartButton = () => (
-  _jsx("button", { type: "button", className: "start-button", children: "\uC2DC\uC791" })
+import { jsxs as _jsxs, jsx as _jsx } from "react/jsx-runtime";
+const StartButton = ({ onClick }) => (
+  _jsxs("button", { type: "button", className: "start-button", onClick, children: [
+    _jsx("img", { className: "start-icon", src: "./images/windows-logo.png", alt: "" }),
+    "\uC2DC\uC791"
+  ] })
 );
 export default StartButton;

--- a/dist/components/Taskbar/Taskbar.js
+++ b/dist/components/Taskbar/Taskbar.js
@@ -1,11 +1,11 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import StartButton from './StartButton.js';
 import TimeDisplay from './TimeDisplay.js';
-const Taskbar = () => (
+const Taskbar = ({ onStartClick }) => (
   _jsxs("div", {
     className: "taskbar",
     children: [
-      _jsx(StartButton, {}),
+      _jsx(StartButton, { onClick: onStartClick }),
       _jsx("div", { style: { flexGrow: 1 } }),
       _jsx(TimeDisplay, {})
     ]

--- a/dist/layout/AppLayout.js
+++ b/dist/layout/AppLayout.js
@@ -1,9 +1,21 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import React from "react";
 import Wallpaper from '../components/Wallpaper.js';
 import Desktop from '../components/Desktop/Desktop.js';
 import WindowArea from '../components/WindowArea/WindowArea.js';
 import Taskbar from '../components/Taskbar/Taskbar.js';
 import StartMenu from '../components/StartMenu/StartMenu.js';
 import PointerTheme from '../components/PointerTheme/PointerTheme.js';
-const AppLayout = () => (_jsxs("div", { style: { position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }, children: [_jsx(Wallpaper, {}), _jsx(Desktop, {}), _jsx(WindowArea, {}), _jsx(Taskbar, {}), _jsx(StartMenu, {}), _jsx(PointerTheme, {})] }));
+const AppLayout = () => {
+  const [showMenu, setShowMenu] = React.useState(false);
+  const toggleMenu = () => setShowMenu(!showMenu);
+  return (_jsxs("div", { style: { position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }, children: [
+    _jsx(Wallpaper, {}),
+    _jsx(Desktop, {}),
+    _jsx(WindowArea, {}),
+    _jsx(Taskbar, { onStartClick: toggleMenu }),
+    showMenu && _jsx(StartMenu, {}),
+    _jsx(PointerTheme, {})
+  ] }));
+};
 export default AppLayout;

--- a/src/components/Taskbar/StartButton.tsx
+++ b/src/components/Taskbar/StartButton.tsx
@@ -5,7 +5,10 @@ interface Props {
 }
 
 const StartButton: React.FC<Props> = ({ onClick }) => (
-  <button type="button" className="start-button" onClick={onClick}>시작</button>
+  <button type="button" className="start-button" onClick={onClick}>
+    <img className="start-icon" src="./images/windows-logo.png" alt="" />
+    시작
+  </button>
 );
 
 export default StartButton;

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -8,7 +8,7 @@ import StartMenu from '../components/StartMenu/StartMenu';
 
 const AppLayout: React.FC = () => {
   const [showMenu, setShowMenu] = React.useState(false);
-  const toggleMenu = () => setShowMenu((v) => !v);
+  const toggleMenu = () => setShowMenu(!showMenu);
 
   return (
     <div style={{ position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }}>

--- a/src/styles/win98.css
+++ b/src/styles/win98.css
@@ -106,6 +106,8 @@ body {
 }
 
 .start-button {
+  display: flex;
+  align-items: center;
   font-size: 0.875rem;
   height: 1.5rem;
   padding: 0 0.5rem;
@@ -115,6 +117,12 @@ body {
   border-bottom: 2px solid #404040;
   border-right: 2px solid #404040;
   background: #c0c0c0;
+}
+
+.start-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 0.25rem;
 }
 
 .time-display {


### PR DESCRIPTION
## Summary
- toggle the start menu when the start button is clicked
- show the Windows logo on the start button

## Testing
- `npx tsc`
- `npm run fix-imports`

------
https://chatgpt.com/codex/tasks/task_e_686159b14164832b9dd83332a0579c6f