### PR TITLE
Add Google link for Internet icon

### DIFF
--- a/dist/components/Desktop/Desktop.js
+++ b/dist/components/Desktop/Desktop.js
@@ -6,7 +6,7 @@ const Desktop = () => (
     children: [
       _jsx(DesktopIcon, { label: "\uB0B4 \uCEF4\uD4E8\uD130", icon: "./images/my-computer.png" }),
       _jsx(DesktopIcon, { label: "\uB0B4 \uBB38\uC11C", icon: "./images/my-document.png" }),
-      _jsx(DesktopIcon, { label: "\uC778\uD130\uB137", icon: "./images/internet.png" }),
+      _jsx(DesktopIcon, { label: "\uC778\uD130\uB137", icon: "./images/internet.png", href: "https://google.com" }),
       _jsx(DesktopIcon, { label: "\uC774\uBA54\uC77C", icon: "./images/email.png", href: "mailto:kdaeyoub@gmail.com" })
     ]
   })

--- a/dist/components/DesktopIcon/DesktopIcon.js
+++ b/dist/components/DesktopIcon/DesktopIcon.js
@@ -2,7 +2,7 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 const DesktopIcon = ({ label, icon, href }) => {
     const handleClick = () => {
         if (href) {
-            window.open(href);
+            window.open(href, '_blank');
         }
         else {
             alert(label);

--- a/src/components/Desktop/Desktop.tsx
+++ b/src/components/Desktop/Desktop.tsx
@@ -5,7 +5,7 @@ const Desktop: React.FC = () => (
   <div className="desktop">
     <DesktopIcon label="내 컴퓨터" icon="./images/my-computer.png" />
     <DesktopIcon label="내 문서" icon="./images/my-document.png" />
-    <DesktopIcon label="인터넷" icon="./images/internet.png" />
+    <DesktopIcon label="인터넷" icon="./images/internet.png" href="https://google.com" />
     <DesktopIcon label="이메일" icon="./images/email.png" href="mailto:kdaeyoub@gmail.com" />
   </div>
 );

--- a/src/components/DesktopIcon/DesktopIcon.tsx
+++ b/src/components/DesktopIcon/DesktopIcon.tsx
@@ -9,7 +9,7 @@ interface Props {
 const DesktopIcon: React.FC<Props> = ({ label, icon, href }) => {
   const handleClick = () => {
     if (href) {
-      window.open(href);
+      window.open(href, '_blank');
     } else {
       alert(label);
     }


### PR DESCRIPTION
## Summary
- link the Internet desktop icon to `https://google.com`
- ensure links open in a new tab

## Testing
- `npx tsc` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6863983f41f0832bbfa489e97268b0f5