### PR TITLE
Fix iOS styles and arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="format-detection" content="telephone=no,address=no,email=no" />
   <title>Windows 98 Mini Homepage</title>
   <link rel="stylesheet" href="./src/styles/win98.css" />
   <script type="importmap">

--- a/src/components/StartMenu/StartMenu.tsx
+++ b/src/components/StartMenu/StartMenu.tsx
@@ -6,10 +6,10 @@ const StartMenu: React.FC = () => (
       <span className="bar-text">Windows</span>
     </div>
     <ul className="start-menu-list">
-      <li className="start-menu-item"><span className="item-icon" />프로그램(P)  <span className="item-arrow">▶</span></li>
-      <li className="start-menu-item"><span className="item-icon" />즐겨찾기(A)  <span className="item-arrow">▶</span></li>
+      <li className="start-menu-item"><span className="item-icon" />프로그램(P)  <span className="item-arrow" /></li>
+      <li className="start-menu-item"><span className="item-icon" />즐겨찾기(A)  <span className="item-arrow" /></li>
       <li className="start-menu-item"><span className="item-icon" />문서(D)</li>
-      <li className="start-menu-item"><span className="item-icon" />설정(S) <span className="item-arrow">▶</span></li>
+      <li className="start-menu-item"><span className="item-icon" />설정(S) <span className="item-arrow" /></li>
       <li className="start-menu-item"><span className="item-icon" />찾기(F)</li>
       <li className="start-menu-item"><span className="item-icon" />도움말(H)</li>
       <li className="start-menu-item"><span className="item-icon" />실행(R)</li>

--- a/src/styles/win98.css
+++ b/src/styles/win98.css
@@ -1,6 +1,7 @@
 body {
   margin: 0;
   overflow: hidden;
+  color: #000;
 }
 
 .wallpaper {
@@ -39,6 +40,7 @@ body {
 .desktop-icon .icon-label {
   font-size: 14px;
   text-align: left;
+  color: #000;
 }
 .desktop-icon .icon-image {
   width: 48px;
@@ -117,6 +119,7 @@ body {
   border-bottom: 2px solid #404040;
   border-right: 2px solid #404040;
   background: #c0c0c0;
+  color: #000;
 }
 
 .start-icon {
@@ -180,6 +183,7 @@ body {
   padding: 0 8px;
   font-size: 16px;
   cursor: default;
+  color: #000;
 }
 
 .start-menu-item:hover {
@@ -196,6 +200,15 @@ body {
 
 .item-arrow {
   margin-left: auto;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 4px solid #000;
+}
+
+.start-menu-item:hover .item-arrow {
+  border-left-color: #fff;
 }
 
 .start-menu-separator {


### PR DESCRIPTION
## Summary
- keep text color black on buttons and menu items
- make start menu arrows via CSS triangles
- disable automatic phone link coloring on iOS

## Testing
- `npx tsc` *(fails: Cannot reach npm registry)*
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6863a518e3fc832bb4a7f0f1afe3e348