### PR TITLE
Fix extra arrow in StartMenu

### DIFF
--- a/dist/components/StartMenu/StartMenu.js
+++ b/dist/components/StartMenu/StartMenu.js
@@ -2,10 +2,10 @@ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 const StartMenu = () => (_jsxs("div", { className: "start-menu", children: [
   _jsxs("div", { className: "start-menu-bar", children: _jsx("span", { className: "bar-text", children: "Windows" }) }),
   _jsxs("ul", { className: "start-menu-list", children: [
-    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uD504\uB85C\uADF8\uB7A8(P) ", _jsx("span", { className: "item-arrow", children: "\u25B6" })] }),
-    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC990\uACA8\uCC3E\uAE30(A) ", _jsx("span", { className: "item-arrow", children: "\u25B6" })] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uD504\uB85C\uADF8\uB7A8(P) ", _jsx("span", { className: "item-arrow" })] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC990\uACA8\uCC3E\uAE30(A) ", _jsx("span", { className: "item-arrow" })] }),
     _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uBB38\uC11C(D)"] }),
-    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC124\uC815(S) ", _jsx("span", { className: "item-arrow", children: "\u25B6" })] }),
+    _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC124\uC815(S) ", _jsx("span", { className: "item-arrow" })] }),
     _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uCC3E\uAE30(F)"] }),
     _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uB3C4\uC6B8\uB9D0(H)"] }),
     _jsxs("li", { className: "start-menu-item", children: [_jsx("span", { className: "item-icon" }), "\uC2E4\uD589(R)"] }),


### PR DESCRIPTION
## Summary
- remove hard-coded arrow text from compiled StartMenu

## Testing
- `npm run build` *(fails: Cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6863f35256fc832ba97ca4d4013d2b94